### PR TITLE
Sprint to v0.2.0

### DIFF
--- a/Default.sublime-mousemap
+++ b/Default.sublime-mousemap
@@ -1,0 +1,9 @@
+[
+    {
+        "button": "button1",
+        "count": 2,
+        "press_command": "drag_select",
+        "command": "exit_outline_mode",
+        "context": [{ "key": "outline_mode" }]
+    },
+]

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Or walk using the arrow keys (or `,`and `.`):
 
 https://github.com/kaste/InlineOutline/assets/8558/d6eca69b-c9b9-46b3-9b66-e61dd6303b47
 
-As usual, `<enter>` will go to to the selected symbol and `<esc>` will reset the
-cursor and viewport.
+As usual, `<enter>` or double-clicking with the mouse will go to to the selected symbol
+and `<esc>` will reset the cursor and viewport.
 
 
 # Key binding

--- a/plugin.py
+++ b/plugin.py
@@ -511,8 +511,12 @@ def find_char_(primer_rest: str, item: str, item_l: str, start: int) -> tuple[in
     # a jump to a complete suffix match does not get the full penalty
     if item.endswith(primer_rest):
         return len(item) - len(primer_rest), 1
-    # typically the penalty is the distance we have to jump
-    return first_seen, first_seen - (start - 1)
+
+    return first_seen, (
+        first_seen - (start - 1)  # typically the penalty is the distance we have to jump
+        if start > 0 else
+        1                         # except for an initial jump
+    )
 
 
 def flip_region(region: sublime.Region) -> sublime.Region:

--- a/plugin.py
+++ b/plugin.py
@@ -386,7 +386,7 @@ class outline_enter_search(sublime_plugin.TextCommand):
             ])
 
             regions_per_line: list[list[sublime.Region]] = [
-                reduce_regions(
+                combine_adjacent_regions(
                     sublime.Region(p + line.region.a, p + line.region.a + 1)
                     for p in sorted(positions)
                 )
@@ -553,7 +553,7 @@ def flash(view: sublime.View, message: str):
         window.status_message(message)
 
 
-def reduce_regions(regions: Iterable[sublime.Region]) -> list[sublime.Region]:
+def combine_adjacent_regions(regions: Iterable[sublime.Region]) -> list[sublime.Region]:
     prev = None
     rv = []
     for r in regions:

--- a/plugin.py
+++ b/plugin.py
@@ -462,7 +462,7 @@ def fuzzy_score(primer: str, item: str) -> tuple[float, list[int]] | None:
         scores.append(_score)
 
         score += _score
-        if score > 10:
+        if score > 5:
             shift = positions[0] + 1
             if scores[0] <= 0 and shift < len(item):
                 # print(f"recurse. matching {primer!r} with {item!r} scored already {score}", positions, scores)

--- a/plugin.py
+++ b/plugin.py
@@ -493,7 +493,6 @@ def find_char_(primer_rest: str, item: str, item_l: str, start: int) -> tuple[in
             # so do jumps to word boundaries
             if idx == start or prev in word_separators or (ch.isupper() and prev.islower()):
                 return idx, (
-                    -1.5 if idx == 0 else  # match at the beginning of item
                     -1 if start == 0 else  # initial wide jump to a boundary
                     0
                 )

--- a/plugin.py
+++ b/plugin.py
@@ -464,7 +464,7 @@ def fuzzy_score(primer: str, item: str) -> tuple[float, list[int]] | None:
 
 
 def find_char(primer_rest, item, item_l, start: int) -> tuple[int, float]:
-    prev = ''
+    prev = ""
     first_seen = -1
     needle = primer_rest[0]
     for idx, ch in enumerate(item[start:], start):

--- a/plugin.py
+++ b/plugin.py
@@ -525,6 +525,7 @@ def find_char_(primer_rest: str, item: str, item_l: str, start: int) -> tuple[in
         ):
             return pos, start - 1 - pos
         raise ValueError(f"can't match {primer_rest!r} with {item!r}")
+
     # a jump to a complete suffix match does not get the full penalty
     if item.endswith(primer_rest):
         return len(item) - len(primer_rest), 1

--- a/plugin.py
+++ b/plugin.py
@@ -446,6 +446,7 @@ def fuzzy_score(primer: str, item: str) -> tuple[float, list[int]] | None:
     primer_l = primer.lower()
     pos, score = -1, 0.0
     positions = []
+    scores = []
     for idx in range(len(primer)):
         try:
             pos, _score = find_char(primer, primer_l, idx, item, item_l, pos + 1)
@@ -453,8 +454,15 @@ def fuzzy_score(primer: str, item: str) -> tuple[float, list[int]] | None:
             return None
 
         positions.append(pos)
+        scores.append(_score)
+
         score += _score
         if score > 10:
+            shift = positions[0] + 1
+            if scores[0] <= 0 and shift < len(item):
+                # print(f"recurse. matching {primer!r} with {item!r} scored already {score}", positions, scores)
+                if (r := fuzzy_score(primer, item[shift:])):
+                    return (r[0], [p + shift for p in r[1]])
             return None
 
     return (score, positions)

--- a/plugin.py
+++ b/plugin.py
@@ -426,18 +426,23 @@ class outline_enter_search(sublime_plugin.TextCommand):
         panel.settings().set("outline_mode_search_panel", True)
 
 
+debug_info: list[tuple[str, tuple, str]] = []
+
+
 def fuzzyfind(primer: str, collection: Iterable[TextRange]) -> list[tuple[TextRange, list[int]]]:
     """
     Fuzzy match a primer, e.g. a search term, against the items in collection.
     """
+    global debug_info
+    debug_info = []
     suggestions = []
     for item in collection:
         if score := fuzzy_score(primer, item.text):
             suggestions.append((score, item))
 
     # print("\n-", primer)
-    # for score, item in sorted(suggestions):
-    #     print("score", score, item.text)
+    # for resolution__, score__, matched_item__ in sorted(debug_info, key=lambda x: x[1]):
+    #     print(f"{resolution__:<6} {score__[0]:>4.1f} {' '.join(map(str, score__[1:])):<50} {matched_item__}")
     return [(item, positions) for (_, positions), item in sorted(suggestions)]
 
 
@@ -463,8 +468,10 @@ def fuzzy_score(primer: str, item: str) -> tuple[float, list[int]] | None:
                 # print(f"recurse. matching {primer!r} with {item!r} scored already {score}", positions, scores)
                 if (r := fuzzy_score(primer, item[shift:])):
                     return (r[0], [p + shift for p in r[1]])
+            debug_info.append(("reject", (score, positions, scores), item))
             return None
 
+    debug_info.append(("match", (score, positions, scores), item))
     return (score, positions)
 
 


### PR DESCRIPTION
- better choose the initially selected symbol.  Instead of choosing the nearest symbol, typically prefer the symbol right above the current position. 
- tune fuzzy matcher.  The original matcher was written to choose from a set of simple tokens.  Here, in our context, we need to match against full lines which obviously contain whitespace and punctuation.  Try to move the algorithm in that (unusual) direction.
- add simple double-click binding which acts like pressing `enter` while on the clicked line. 